### PR TITLE
Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "automated"
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
## Summary
- Configured Dependabot to monitor and update Composer dependencies automatically

## Configuration Details
- **Package ecosystem**: Composer
- **Update schedule**: Weekly on Mondays at 09:00
- **PR limit**: Maximum 5 open PRs at a time
- **Labels**: `dependencies`, `automated`
- **Commit message prefix**: `chore`

## Benefits
- Automated security updates
- Stay current with dependency patches
- Reduce manual dependency management overhead
- Get notified of breaking changes early

Closes #30